### PR TITLE
Backport for Play 2.2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-# HikariCP Plugin for 2.3.x
+# HikariCP Plugin for 2.2.x
 
-This plugin works with `2.3.x` of PlayFramework. It uses version `2.0.1` of HikariCP.
+This branch of the plugin works with `2.2.x` of PlayFramework. It uses version `2.0.1` of HikariCP.
 
-Note, it can be made to work with Play `2.2.x` of the PlayFramework, but it requires changing the dependencies as
-the current build relies on the Play `2.3.x` plugin.
+See the master branch for the plugin for Play! `2.3.x`.
 
 [![Build Status](https://travis-ci.org/edulify/play-hikaricp.edulify.com.svg?branch=master)](https://travis-ci.org/edulify/play-hikaricp.edulify.com)
 
@@ -17,16 +16,17 @@ Here is how HikariCP is working for us:
 
 ## Versions
 
-| Version | HikariCP | Play  | Comment                          |
-|--------:|---------:|------:|:---------------------------------|
-| 1.5.0   | 2.0.1    | 2.3.4 | Code cleanup and fail fast in case of misconfiguration |
-| 1.4.1   | 2.0.1    | 2.3.2 | Updates HikariCP, Scala and Play |
-| 1.4.0   | 1.4.0    | 2.3.1 | JNDI support and HikariCP 1.4.0  |
-| 1.3.1   | 1.3.8    | 2.3.1 | Corrects artifact name           |
-| 1.3.0   | 1.3.8    | 2.3.1 | Updates Play and Scala versions  |
-| 1.2.0   | 1.3.8    | 2.2.3 | Supports Heroku like services    |
-| 1.1.0   | 1.3.8    | 2.2.3 | Updates HikariCP and Play        |
-| 1.0.0   | 1.3.5    | 2.2.2 | First stable release             |
+| Version      | HikariCP | Play  | Comment                          |
+|-------------:|---------:|------:|:---------------------------------|
+| 1.5.0-2.2.x  | 2.0.1    | 2.2.3 | Code cleanup and fail fast in case of misconfiguration | 
+| 1.5.0        | 2.0.1    | 2.3.4 | Code cleanup and fail fast in case of misconfiguration |
+| 1.4.1        | 2.0.1    | 2.3.2 | Updates HikariCP, Scala and Play |
+| 1.4.0        | 1.4.0    | 2.3.1 | JNDI support and HikariCP 1.4.0  |
+| 1.3.1        | 1.3.8    | 2.3.1 | Corrects artifact name           |
+| 1.3.0        | 1.3.8    | 2.3.1 | Updates Play and Scala versions  |
+| 1.2.0        | 1.3.8    | 2.2.3 | Supports Heroku like services    |
+| 1.1.0        | 1.3.8    | 2.2.3 | Updates HikariCP and Play        |
+| 1.0.0        | 1.3.5    | 2.2.2 | First stable release             |
 
 ## Repository
 

--- a/module-code/build.sbt
+++ b/module-code/build.sbt
@@ -1,12 +1,8 @@
+import play.Project._
+
 name := "play-hikaricp"
 
-version := "1.5.0"
-
-scalaVersion := "2.11.2"
-
-crossScalaVersions := Seq("2.10.4", "2.11.2")
-
-lazy val root = (project in file(".")).enablePlugins(PlayScala)
+version := "1.5.0-2.2.x"
 
 libraryDependencies ++= Seq(
   jdbc,
@@ -64,4 +60,6 @@ pomExtra := (
   )
 
 scalacOptions := Seq("-feature", "-deprecation")
+
+playScalaSettings
 

--- a/module-code/project/build.properties
+++ b/module-code/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.0

--- a/module-code/project/plugins.sbt
+++ b/module-code/project/plugins.sbt
@@ -16,7 +16,7 @@ addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
 
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.4.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % System.getProperty("play.version", "2.3.4"))
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % System.getProperty("play.version", "2.2.3"))
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
 


### PR DESCRIPTION
Please consider a separate branch for Play 2.2.x, as I have here. It will publish to a version 1.5.0-2.2.x, useful for 2.2.x users to get some important bug fixes from HikariCP 2. 