### PR TITLE
Added databaseUrl to allow for direct usage of DATABASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,32 +178,12 @@ Thanks to contributions from the community, this plugin supports to bind a DataS
 
 ## Deploying to Heroku
 
-When using Heroku, you first need to translate its `DATABASE_URL` into another variable with the format expected by PostgreSQL JDBC Driver. As stated by [Heroku docs](https://devcenter.heroku.com/articles/heroku-postgresql#spring-java):
-
-> The `DATABASE_URL` for the Heroku Postgres add-on follows this naming convention:
->
->     postgres://<username>:<password>@<host>/<dbname>
->
-> However the Postgres JDBC driver uses the following convention:
->
->     jdbc:postgresql://<host>:<port>/<dbname>?user=<username>&password=<password>
->
-> Notice the additional `ql` at the end of `jdbc:postgresql`? Due to this difference you will need to hardcode the scheme to jdbc:postgresql` in your Java class or your Spring XML configuration.
-
-So, you will need to create another environment variable with the proper format and you will also need to create variables for username and password. To do this, run the following commands:
-
-      $ heroku config:set DATABASE_JDBC_URL="jdbc:postgresql://host:5432/dbname"
-      $ heroku config:set DATABASE_USERNAME=username
-      $ heroku config:set DATABASE_PASSWORD=password
-
-You can obtain the correct values for `host`, `dbname`, `username`, and `password` from the `DATABASE_URL` environment variable, which Heroku creates for you. Then you can use these variables directly inside `application.conf`, since it is supported by [Typesafe Config](https://github.com/typesafehub/config):
+When using Heroku, a `DATABASE_URL` environment variable in the form `scheme://user:password@host:port/db` will be created for you. This variable can be used directly inside `application.conf`:
 
     db {
       default {
         driverClassName=org.postgresql.Driver
-        jdbcUrl=${DATABASE_JDBC_URL}
-        username=${DATABASE_USERNAME}
-        password=${DATABASE_PASSWORD}
+        databaseUrl=${DATABASE_URL}
       }
     }
 

--- a/test/com/edulify/play/hikaricp/HikariCPConfigSpec.scala
+++ b/test/com/edulify/play/hikaricp/HikariCPConfigSpec.scala
@@ -35,6 +35,17 @@ class HikariCPConfigSpec extends Specification {
       HikariCPConfig.toHikariConfig(config).getDataSourceClassName == "org.postgresql.ds.PGPoolingDataSource"
     }
 
+    "set databaseUrl when present" in {
+      val properties = new Properties()
+      properties.setProperty("databaseUrl", "postgres://foo:bar@host:1234/dbname")
+      val config = new Configuration(ConfigFactory.parseProperties(properties))
+      val hikariConfig: HikariConfig = HikariCPConfig.toHikariConfig(config)
+
+      hikariConfig.getJdbcUrl == "jdbc:postgresql://host:1234/dbname"
+      hikariConfig.getUsername == "foo"
+      hikariConfig.getPassword == "bar"
+    }
+
     "set jdbcUrl when present" in {
       val properties = new Properties()
       properties.setProperty("jdbcUrl", "jdbc:postgresql://host/database")


### PR DESCRIPTION
Added databaseUrl to allow for direct usage of DATABASE_URL env var, without manual parsing. This would allow for some parity with Play+BoneCP as described in the [Play documentation for JDBC config](https://playframework.com/documentation/2.3.x/SettingsJDBC).

To achieve full parity, it would need to set the driverClass automatically, and use `url` instead of `databaseUrl`. I'll be happy to make that change if desired.