### PR TITLE
(refs #65)Config translation for basic jdbc connection settings

### DIFF
--- a/app/com/edulify/play/hikaricp/HikariCPConfig.scala
+++ b/app/com/edulify/play/hikaricp/HikariCPConfig.scala
@@ -30,7 +30,7 @@ object HikariCPConfig {
       case None => Logger.debug("`dataSourceClassName` not present. Will use `jdbcUrl` instead.")
     }
 
-    config.getString("jdbcUrl") match {
+    config.getString("jdbcUrl").orElse(config.getString("url")) match {
       case Some(jdbcUrl) => hikariConfig.setJdbcUrl(jdbcUrl)
       case None => Logger.debug("`jdbcUrl` not present. Pool configured from `databaseUrl`.")
     }
@@ -55,10 +55,10 @@ object HikariCPConfig {
       }
     }
 
-    config.getString("username").foreach(hikariConfig.setUsername)
+    config.getString("username").orElse(config.getString("user")).foreach(hikariConfig.setUsername)
     config.getString("password").foreach(hikariConfig.setPassword)
 
-    config.getString("driverClassName").foreach(hikariConfig.setDriverClassName)
+    config.getString("driverClassName").orElse(config.getString("driver")).foreach(hikariConfig.setDriverClassName)
 
     // Frequently used
     config.getBoolean("autoCommit").foreach(hikariConfig.setAutoCommit)

--- a/test/com/edulify/play/hikaricp/HikariCPConfigSpec.scala
+++ b/test/com/edulify/play/hikaricp/HikariCPConfigSpec.scala
@@ -54,6 +54,14 @@ class HikariCPConfigSpec extends Specification {
       HikariCPConfig.toHikariConfig("testDataSource", config).getJdbcUrl == "jdbc:postgresql://host/database"
     }
 
+    "set url when present" in {
+      val properties = new Properties()
+      properties.setProperty("url", "jdbc:postgresql://host/database")
+      properties.setProperty("user", "user")
+      val config = new Configuration(ConfigFactory.parseProperties(properties))
+      HikariCPConfig.toHikariConfig("testDataSource", config).getJdbcUrl == "jdbc:postgresql://host/database"
+    }
+
     "discard configuration not related to hikari config" in new Configs {
       val props = valid
       props.setProperty("just.some.garbage", "garbage")


### PR DESCRIPTION
Restores config translation for:

- driver -> driverClassName
- url -> jdbcUrl
- user -> username

See #65 also.